### PR TITLE
Fix to whitespace-chars in spec.clj

### DIFF
--- a/src/ring/core/spec.clj
+++ b/src/ring/core/spec.clj
@@ -27,7 +27,7 @@
   (into alphanumeric-chars #{\! \# \$ \% \& \' \* \+ \- \. \^ \_ \` \| \~}))
 
 (def ^:private whitespace-chars
-  #{0x09 0x20})
+  #{(char 0x09) (char 0x20)})
 
 (def ^:private visible-chars
   (set (map char (range 0x21 (inc 0x7e)))))


### PR DESCRIPTION
Was trying to use spec.clj to spec my own functions returning ring response maps and found that white space in headers (specifically in the date-time value of the Last-Modified header) wasn't passing spec.  This change fixes the issue.